### PR TITLE
bug/21 Invalid lap session data was causing issues

### DIFF
--- a/lib/storage/src/storage.cpp
+++ b/lib/storage/src/storage.cpp
@@ -124,7 +124,7 @@ namespace
             sector1Time(0U),
             sector2Time(0U),
             sector3Time(0U),
-            firstLap(false)
+            firstLap(true)
         {}
     };
 
@@ -208,6 +208,24 @@ namespace
     }
 
     //------------------------------------------------------------------------
+    void ResetSessionStateAfterPurge()
+    {
+        _ramData.logPosition = 0;
+        _ramData.logTimeBegin = 0U;
+
+        _sessionData.sessionActive = false;
+        _sessionData.lastUpdateTime = 0U;
+        _sessionData.currentLogFile = "";
+        _sessionData.currentTimeLogFile = "";
+        _sessionData.currentSummaryFile = "";
+        _sessionData.currentTimeStamp = "";
+
+        _lapData = LapTimingSessionInfo{};
+        WayPoints::ResetRecentLocations();
+    }
+
+
+    //------------------------------------------------------------------------
     void WriteSessionSummary(Storage::SessionType sessionType)
     {
         // Summary file name was never updated. Don't create the file.
@@ -269,6 +287,9 @@ namespace
     {
         if (time.valid)
         {
+            _lapData = LapTimingSessionInfo{};
+            WayPoints::ResetRecentLocations();
+
             char timestamp[25];
             sprintf(timestamp, "%04d%02d%02d_%02d%02d%02d",
                                 time.year,
@@ -337,7 +358,6 @@ namespace
 
             Led::TurnLedOn();
 
-            _lapData.firstLap          = true;
             _sessionData.sessionActive = true;
         }
     }
@@ -420,7 +440,6 @@ namespace
         FlushRamToFlash();
         WriteSessionSummary(Storage::SessionType::LAP_TIMING);
         _sessionData.currentSummaryFile = "";
-        _lapData.lapNumber = 0;
 
         Led::TurnLedOff();
         Led::StartOneShotBlink(END_SESSION_BLINK_INTERVAL, END_SESSION_BLINK_INTERVAL * 4);
@@ -836,6 +855,11 @@ namespace Storage
         }
 
         const bool purged = RemoveFileSystemEntries(entries);
+
+        if (purged)
+        {
+            ResetSessionStateAfterPurge();
+        }
 
         return purged;
     }

--- a/lib/waypoints/src/waypoints.cpp
+++ b/lib/waypoints/src/waypoints.cpp
@@ -35,6 +35,9 @@ namespace
     // Array of the 2 most recent coordinate locations
     WayPoints::RecentLocations _storedLocations;
 
+    // Whether there is enough recent location history to test crossings
+    bool _havePreviousLocation = false;
+
     // Collection of session distance information
     SessionDistance _sessionDisInfo;
 
@@ -101,10 +104,25 @@ namespace WayPoints
     //------------------------------------------------------------------------
     void StoreCurrentLocation(const WayPoints::Coord& point)
     {
+        if (!_havePreviousLocation)
+        {
+            _storedLocations.front() = point;
+            _storedLocations.back() = point;
+            _havePreviousLocation = true;
+            return;
+        }
+
         // back() is the previous location. front() is the current.
         // So the front becomes the back, and the current becomes the front.
         _storedLocations.back()  = _storedLocations.front();
         _storedLocations.front() = point;
+    }
+
+    //------------------------------------------------------------------------
+    void ResetRecentLocations()
+    {
+        _storedLocations = RecentLocations{};
+        _havePreviousLocation = false;
     }
 
     //------------------------------------------------------------------------
@@ -141,6 +159,11 @@ namespace WayPoints
     //------------------------------------------------------------------------
     bool WaypointCrossed(const unsigned currentSector)
     {
+        if (!_havePreviousLocation)
+        {
+            return false;
+        }
+
         const WayPoint& currentWaypoint(_trackWaypoints.at(currentSector));
 
         return(   currentWaypoint.isActive

--- a/lib/waypoints/src/waypoints.h
+++ b/lib/waypoints/src/waypoints.h
@@ -58,6 +58,9 @@ namespace WayPoints
     // back the previous location.
     void StoreCurrentLocation(const WayPoints::Coord& point);
 
+    // Resets the recent location history used for line crossing checks.
+    void ResetRecentLocations();
+
     // Reset the session distance counter for a new session.
     void ResetSessionDistance();
 


### PR DESCRIPTION
Changed lap session starts to initialize _lapData as well as only do intersection logic when there is a valid location. When storing the current location, if its the first it will store both locations instead of putting a garbage value