### PR TITLE
bug/15 Fixed initialization logic

### DIFF
--- a/lib/display/src/display.cpp
+++ b/lib/display/src/display.cpp
@@ -30,7 +30,10 @@ namespace
     constexpr unsigned ADC_CTRL = 37;
 
     // Initial setup flag.
-    bool initialized = false;
+    bool _initialized = false;
+
+    // Permanent draw flag.
+    bool _permDrawsDone = false;
 
     unsigned long _lastDrawTime = 0;
 
@@ -93,21 +96,41 @@ namespace Display
         pinMode(ADC_CTRL, OUTPUT);
         digitalWrite(ADC_CTRL, LOW);
         analogReadResolution(12);
-        initialized = _display.init();
+        _initialized = _display.init();
 
-        if (initialized)
+        if (_initialized)
         {
+            _display.clear();
             _display.setFont(DisplayAssets::Roboto_Light_14);
             _display.drawString(34, 4, "Lap Timer");
             _display.drawString(58, 30, "By");
             _display.drawString(7, 48, "Carter Hildebrandt");
             _display.display();
-            delay(5000);
-
-            PermDraws();
         }
 
-        return initialized;
+        return _initialized;
+    }
+
+    //------------------------------------------------------------------------
+    void DetermineSplashScreen(bool systemInitialized)
+    {
+        // The display was the object that didn't display. Do nothing
+        if (!_initialized)
+        {
+            return;
+        }
+
+        // System isn't healthy, display the failed splashscreen
+        if (!systemInitialized)
+        {
+            _display.clear();
+            _display.drawString(10, 4, "Something failed");
+            _display.drawString(30, 22, "to initialize");
+            _display.drawCircle(64, 48, 5);
+            _display.drawLine(68, 42, 60, 54);
+            _display.drawLine(60, 42, 68, 54);
+            _display.display();
+        }
     }
 
     //------------------------------------------------------------------------
@@ -116,6 +139,12 @@ namespace Display
         if (millis() - _lastDrawTime > SCREEN_REFRESH_RATE)
         {
             _lastDrawTime = millis();
+
+            if (!_permDrawsDone)
+            {
+                PermDraws();
+                _permDrawsDone = true;
+            }
 
             DrawCurrentMode(status.mode);
 

--- a/lib/display/src/display.h
+++ b/lib/display/src/display.h
@@ -35,9 +35,15 @@ namespace Display
 		{}
 	};
 
+	// How long to display the splashscreen for
+	constexpr unsigned SPLASH_MINIMUM_TIME = 5000U;
+
     // Initializes the display while also drawing the basic sector times.
 	// Returns a boolean for whether or no the display was properly initialized.
 	bool InitializeDisplay();
+
+	// If the ESP32 doesn't initialize, display the failed initialization splashscreen.
+	void DetermineSplashScreen(bool initialized);
 
 	// Draws the status screen based.
 	void UpdateScreen(const StatusSnapshot& status);

--- a/lib/gps/src/gps.cpp
+++ b/lib/gps/src/gps.cpp
@@ -46,10 +46,8 @@ namespace GPS
     bool InitializeUBLOX()
     {    
         _GPSHardwareSerial.begin(115200, SERIAL_8N1, GPS_Rx, GPS_Tx);
-        delay(1000);
         
         initialized = _gps.begin(_GPSHardwareSerial);
-        delay(1000);
 
         return initialized;
     }

--- a/lib/prefs/src/prefs.cpp
+++ b/lib/prefs/src/prefs.cpp
@@ -38,37 +38,39 @@ namespace
 namespace Prefs
 {
     //------------------------------------------------------------------------
-    void InitializePrefs()
+    bool InitializePrefs()
     {
-        if (!_prefs.begin(PREF_NAMESPACE, true))
+        bool success = _prefs.begin(PREF_NAMESPACE, true);
+
+        if (success)
         {
-            return;
+            uint8_t sessionTypeValue = _prefs.getUChar(
+                SESSION_TYPE_KEY,
+                static_cast<uint8_t>(DEFAULT_SESSION_TYPE)
+            );
+
+            Storage::SessionType sessionType =
+                static_cast<Storage::SessionType>(sessionTypeValue);
+
+            if (IsValidSessionType(sessionType))
+            {
+                _persistantConfig.sessionType = sessionType;
+            }
+            else
+            {
+                _persistantConfig.sessionType = DEFAULT_SESSION_TYPE;
+            }
+
+            _persistantConfig.lapLogHz =
+                _prefs.getUInt(LAP_FREQ_KEY, DEFAULT_LAP_FREQUENCY);
+
+            _persistantConfig.routeLogHz =
+                _prefs.getUInt(ROUTE_FREQ_KEY, DEFAULT_ROUTE_FREQUENCY);
+
+            _prefs.end();
         }
 
-        uint8_t sessionTypeValue = _prefs.getUChar(
-            SESSION_TYPE_KEY,
-            static_cast<uint8_t>(DEFAULT_SESSION_TYPE)
-        );
-
-        Storage::SessionType sessionType =
-            static_cast<Storage::SessionType>(sessionTypeValue);
-
-        if (IsValidSessionType(sessionType))
-        {
-            _persistantConfig.sessionType = sessionType;
-        }
-        else
-        {
-            _persistantConfig.sessionType = DEFAULT_SESSION_TYPE;
-        }
-
-        _persistantConfig.lapLogHz =
-            _prefs.getUInt(LAP_FREQ_KEY, DEFAULT_LAP_FREQUENCY);
-
-        _persistantConfig.routeLogHz =
-            _prefs.getUInt(ROUTE_FREQ_KEY, DEFAULT_ROUTE_FREQUENCY);
-
-        _prefs.end();
+        return success;
     }
 
     //------------------------------------------------------------------------

--- a/lib/prefs/src/prefs.h
+++ b/lib/prefs/src/prefs.h
@@ -27,7 +27,7 @@ namespace Prefs
         {}
     };
 
-    void InitializePrefs();
+    bool InitializePrefs();
 
     const Config& PersistConfig();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,13 +13,41 @@ void setup() {
     Button::InitializeButton();
     Led::InitializeLed();
 
+    // Start the blinking to signal the device is booting up.
     Led::StartBlink(250U);
-    Prefs::InitializePrefs();
-    Display::InitializeDisplay();
-    Storage::InitializeStorage();
-    GPS::InitializeUBLOX();
+
+    // Get the start of initialization.
+    unsigned long splashStart = millis();
+
+    bool displayOk = Display::InitializeDisplay();
+    bool prefsOk   = Prefs::InitializePrefs();
+    bool storageOk = Storage::InitializeStorage();
+    bool gpsOk     = GPS::InitializeUBLOX();
     BLE::InitializeBLE();
 
+    bool initialized = displayOk && prefsOk && storageOk && gpsOk;
+
+    // Display the splashscreen for atleast 5 seconds.
+    while (millis() - splashStart <= Display::SPLASH_MINIMUM_TIME)
+    {
+        delay(10);
+    }
+    
+    // Determine whether to display the failed start screen.
+    Display::DetermineSplashScreen(initialized);
+
+    if (!initialized)
+    {
+        // Only start the blink once.
+        Led::StartBlink(100U);
+
+        while(!initialized)
+        {
+            // Do nothing. ESP32 failed to start.
+        }
+    }
+
+    // System is green. Continue with logic.
     Led::StopBlink();
 }
 


### PR DESCRIPTION
The logic order is now:

Initial splash screen ->
Initialize all other systems ->
Wait a minimum of 5 seconds ->
If initialized, continue onto loop(), otherwise display a failed initialization splashscreen and halt all other logic.