### PR TITLE
38 Add battery percentage session start/stop gates

### DIFF
--- a/lib/battery/src/battery.cpp
+++ b/lib/battery/src/battery.cpp
@@ -79,6 +79,8 @@ namespace
 
     constexpr size_t BATTERY_VOLTAGE_AVG_SAMPLES = 16;
 
+    constexpr unsigned long BATTERY_READ_INTERVAL = 1000U;
+
     constexpr Point CURVE[] = {
         {4.20f, 100}, {4.10f, 90}, {4.00f, 80}, {3.92f, 70},
         {3.85f, 60},  {3.79f, 50}, {3.75f, 40}, {3.70f, 30},
@@ -107,6 +109,8 @@ namespace
     };
 
     AverageVoltage _avgBattVolt;
+
+    unsigned long lastBatteryRead = 0U;
 
     //------------------------------------------------------------------------
     void AddSample(float newSample)
@@ -184,20 +188,10 @@ namespace Battery
     }
 
     //------------------------------------------------------------------------
-    float ReadVoltage()
+    float ReadInstantVoltage()
     {
         uint32_t millivolts = analogReadMilliVolts(VADC_IN);
-
-        const float voltage = (millivolts / 1000.0f) * BATTERY_DIVIDER * BATTERY_CALIBRATION;
-
-        // We only care about percentage if the ESP32 is connected
-        // to a battery.
-        if (DEVICE_HAS_BATTERY)
-        {
-            AddSample(voltage);
-        }
-
-        return voltage;
+        return (millivolts / 1000.0f) * BATTERY_DIVIDER * BATTERY_CALIBRATION;
     }
 
     //------------------------------------------------------------------------
@@ -210,5 +204,17 @@ namespace Battery
         }
 
         return Percentage(_avgBattVolt.sum / _avgBattVolt.count);
+    }
+
+    //------------------------------------------------------------------------
+    void UpdateBatteryPercentage()
+    {
+        if (DEVICE_HAS_BATTERY
+          && (millis() - lastBatteryRead) >= BATTERY_READ_INTERVAL)
+        {
+            lastBatteryRead = millis();
+
+            AddSample(ReadInstantVoltage());
+        }
     }
 }

--- a/lib/battery/src/battery.h
+++ b/lib/battery/src/battery.h
@@ -12,12 +12,16 @@ namespace Battery
     // This is a user set value, not detected.
     bool IsConnected();
 
-    // Reads the battery voltage and stores it in the rolling average.
-    float ReadVoltage();
+    // Reads the battery voltage and returns it.
+    float ReadInstantVoltage();
 
     // Returns the average battery percentage based on the rolling
     // average of the read in battery voltages.
     int AveragePercentage();
+
+    // Should be called continuously in the main loop to provide an
+    // accurate battery reading whenever needed.
+    void UpdateBatteryPercentage();
 };
 
 #endif

--- a/lib/ble/src/ble.cpp
+++ b/lib/ble/src/ble.cpp
@@ -961,7 +961,7 @@ namespace
             power = "external";
         }
 
-        float voltage = Battery::ReadVoltage();
+        float voltage = Battery::ReadInstantVoltage();
         int percent   = Battery::AveragePercentage();
 
         const GPS::FixData fixData(GPS::GetFixData());

--- a/lib/display/src/display.cpp
+++ b/lib/display/src/display.cpp
@@ -219,8 +219,6 @@ namespace Display
 
             if (Battery::IsConnected())
             {
-                Battery::ReadVoltage();
-
                 char subLine1[10];
                 sprintf(subLine1, "%d%%", Battery::AveragePercentage());
 

--- a/lib/storage/src/storage.cpp
+++ b/lib/storage/src/storage.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 #include <prefs.h>
 #include <gps.h>
+#include <battery.h>
 
 //----------------------------------------------------------------------------
 // Private namespace
@@ -40,6 +41,9 @@ namespace
     // Constant for the amount of time that must pass before another waypoint
     // crossing is detected
     constexpr unsigned long WAYPOINT_CROSSING_JITTER = 5000U;
+
+    constexpr int SESSION_STOP_BATTERY_THRESHOLD = 2;
+    constexpr int SESSION_START_BATTERY_THRESHOLD = 5;
 
     // Data associated with the ram buffer
     struct RamData
@@ -642,11 +646,35 @@ namespace Storage
     //------------------------------------------------------------------------
     void SessionStartStop(const GPS::FixData& data, const Button::Mode mode)
     {
+        // If the ESP32 is connected to battery power, run logic that
+        // determines if a session should be stopped if the battery
+        // percentage drops below a threshold. Don't use battery voltage
+        // since that does not have a rolling average and is prone to jitter.
+        if (Battery::IsConnected() && _sessionData.sessionActive)
+        {
+            if (Battery::AveragePercentage() <= SESSION_STOP_BATTERY_THRESHOLD)
+            {
+                switch (_sessionData.sessionType)
+                {
+                    case Storage::SessionType::LAP_TIMING:
+                        EndLapSession();
+                        break;
+                    case Storage::SessionType::ROUTE_TRACKING:
+                        EndRouteSession();
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
         // Short button press is related to start/stopping session logic
         if (mode == Button::Mode::SHORT)
         {
             // No session is active, start a new one
-            if (!_sessionData.sessionActive && data.valid)
+            if (!_sessionData.sessionActive && data.valid
+                  && (!Battery::IsConnected()
+                    || Battery::AveragePercentage() >= SESSION_START_BATTERY_THRESHOLD))
             {
                 switch (_sessionData.sessionType)
                 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,6 +69,9 @@ void loop() {
         BLE::GetStatus()
     };
 
+    // Update the battery percentage
+    Battery::UpdateBatteryPercentage();
+
     // Screen updates can be done even if fix data is not valid.
     Display::UpdateScreen(status);
 


### PR DESCRIPTION
Changed battery percentage updates to be continuously called in main. That way other functions needing the percentage can just grab the average percentage. Added to SessionStartStop to stop active sessions if the battery percetage drops below a set threshold as well as preventing new sessions from being started.